### PR TITLE
run bundle install for simple form and devise

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -145,6 +145,3 @@ DEPENDENCIES
   sprockets (= 2.11.0)
   turbolinks
   uglifier (>= 1.3.0)
-
-BUNDLED WITH
-   1.10.6


### PR DESCRIPTION
Fix error between devise and simple form by running bundle install
