### PR TITLE
fix creating multiple game pieces when a player uses backarrow in a browser

### DIFF
--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -59,12 +59,12 @@ class GamesController < ApplicationController
         # p @game_piece.user_id
         opponent = @game.get_enemy_of(@game_piece.user_id)
         if !@game.can_attack?(opponent, new_x, new_y)
-         move_save(new_x, new_y)
+          move_save(new_x, new_y)
         else
           flash[:notice] = "King cannot be moved in check position!"
         end
       else
-          move_save(new_x, new_y)
+        move_save(new_x, new_y)
       end
     else
       # can't move there!

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -4,12 +4,14 @@ class Game < ActiveRecord::Base
   belongs_to :player_black, :class_name => "User", :foreign_key => "player_black_id"
 
   def populate_pieces!
-    game_piece_rank = ["Rook", "Knight", "Bishop", "Queen", "King", "Bishop", "Knight", "Rook"]
-    (0..7).each do |i|
-      game_pieces << (game_piece_rank[i].constantize).new(x: i, y: 0, game_id: self.id, user_id: player_white_id)  #player 1
-      game_pieces << Pawn.new(x: i, y: 1, game_id: self.id, user_id: player_white_id)  #player 1
-      game_pieces << (game_piece_rank[i].constantize).new(x: i, y: 7, game_id: self.id, user_id: player_black_id)  #player 2
-      game_pieces << Pawn.new(x: i, y: 6, game_id: self.id, user_id: player_black_id)  #player 2
+    if (self.game_pieces.where(game_id: self.id).take.nil?)
+      game_piece_rank = ["Rook", "Knight", "Bishop", "Queen", "King", "Bishop", "Knight", "Rook"]
+      (0..7).each do |i|
+        game_pieces << (game_piece_rank[i].constantize).new(x: i, y: 0, game_id: self.id, user_id: player_white_id)  #player 1
+        game_pieces << Pawn.new(x: i, y: 1, game_id: self.id, user_id: player_white_id)  #player 1
+        game_pieces << (game_piece_rank[i].constantize).new(x: i, y: 7, game_id: self.id, user_id: player_black_id)  #player 2
+        game_pieces << Pawn.new(x: i, y: 6, game_id: self.id, user_id: player_black_id)  #player 2
+      end
     end
   end
 


### PR DESCRIPTION
A bug fix.  
(the situation: after a game is created, and another player joins, the second player can user a back arrow of a browser to keep pushing "join" button.  If that happens, the multiple sets of game pieces are created.  Added to check to see if game pieces exist.  If so, it won't create another set.)
